### PR TITLE
remove namespace

### DIFF
--- a/as-packages/as-contract-runtime/package.json
+++ b/as-packages/as-contract-runtime/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ask-lang/as-contract-runtime",
+  "name": "as-contract-runtime",
   "version": "0.4.0-rc0",
   "description": "as version of contract runtime primitives",
   "author": "Ask! Authors <https://github.com/ask-lang>",

--- a/as-packages/lang/assembly/collections/mapping.ts
+++ b/as-packages/lang/assembly/collections/mapping.ts
@@ -2,7 +2,7 @@ import { ScaleSerializer } from "as-serde-scale";
 import { IKey, SpreadLayout, IHash256 } from "../interfaces";
 import { Key } from "../types";
 import { env } from "../env/onchain";
-import { ReturnCode } from "@ask-lang/as-contract-runtime";
+import { ReturnCode } from "as-contract-runtime";
 
 /**
  * A simple hashmap which is not iterable and set/get data immediately.

--- a/as-packages/lang/assembly/crypto/index.ts
+++ b/as-packages/lang/assembly/crypto/index.ts
@@ -1,4 +1,4 @@
-import { seal0 } from "@ask-lang/as-contract-runtime";
+import { seal0 } from "as-contract-runtime";
 import { FixedArray } from "../fixedArrays";
 import { IHash128, IHash256 } from "../interfaces";
 

--- a/as-packages/lang/assembly/env/onchain.ts
+++ b/as-packages/lang/assembly/env/onchain.ts
@@ -1,4 +1,4 @@
-import { seal0, seal1, ReturnCode } from "@ask-lang/as-contract-runtime";
+import { seal0, seal1, ReturnCode } from "as-contract-runtime";
 import { ScaleSerializer, ScaleDeserializer, BytesBuffer } from "as-serde-scale";
 import { IEvent, IKey, TypedEnvBackend } from "../interfaces";
 import { RandomResult, StorageResult } from "../types";

--- a/as-packages/lang/assembly/internal/buffer.ts
+++ b/as-packages/lang/assembly/internal/buffer.ts
@@ -1,4 +1,4 @@
-import { seal0 } from "@ask-lang/as-contract-runtime";
+import { seal0 } from "as-contract-runtime";
 
 // TODO: we need support larger input data
 export let STORAGE_BUFFER_SIZE: i32 = 1024;

--- a/as-packages/lang/assembly/storage/packed.ts
+++ b/as-packages/lang/assembly/storage/packed.ts
@@ -2,7 +2,7 @@ import { i128, u128 } from "as-bignum";
 import { PackedLayout, IKey } from "../interfaces";
 import { env } from "../env";
 import { FixedArray } from "../fixedArrays";
-import { ReturnCode } from "@ask-lang/as-contract-runtime";
+import { ReturnCode } from "as-contract-runtime";
 import { StorageResult } from "../types";
 
 /**

--- a/as-packages/lang/assembly/types/storageResult.ts
+++ b/as-packages/lang/assembly/types/storageResult.ts
@@ -1,4 +1,4 @@
-import { ReturnCode } from "@ask-lang/as-contract-runtime";
+import { ReturnCode } from "as-contract-runtime";
 import { instantiateRaw } from "as-serde-scale";
 
 /**

--- a/as-packages/lang/package.json
+++ b/as-packages/lang/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ask-lang/ask-lang",
+  "name": "ask-lang",
   "version": "0.4.0-rc0",
   "description": "Ask lang sdk",
   "main": "index.ts",
@@ -20,7 +20,7 @@
   "dependencies": {
     "as-bignum": "^0.2.23",
     "as-buffers": "^0.1.2",
-    "@ask-lang/as-contract-runtime": "0.4.0-rc0",
+    "as-contract-runtime": "0.4.0-rc0",
     "as-serde": "^0.1.1",
     "as-serde-scale": "^0.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "yarn workspaces run test",
     "test:as": "asp --verbose",
     "test:as:summary": "asp --summary",
-    "build": "yarn workspace @ask-lang/contract-metadata build && yarn workspace @ask-lang/ask-transform build"
+    "build": "yarn workspace contract-metadata build && yarn workspace ask-transform build"
   },
   "private": true,
   "devDependencies": {

--- a/ts-packages/contract-metadata/package.json
+++ b/ts-packages/contract-metadata/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ask-lang/contract-metadata",
+  "name": "contract-metadata",
   "version": "0.4.0-rc0",
   "description": "Metadata specs about substrate smart contract for assemblyscript",
   "author": "Ask! Authors <https://github.com/ask-lang>",

--- a/ts-packages/transform/package.json
+++ b/ts-packages/transform/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ask-lang/ask-transform",
+  "name": "ask-transform",
   "version": "0.4.0-rc0",
   "description": "AssemblyScript transformer for building ask projects",
   "main": "dist/index.js",
@@ -29,7 +29,7 @@
   "dependencies": {
     "assemblyscript": "^0.19",
     "blakejs": "^1.1.0",
-    "@ask-lang/contract-metadata": "0.4.0-rc0",
+    "contract-metadata": "0.4.0-rc0",
     "debug": "^4.3",
     "lodash": "4.17",
     "visitor-as": "0.8"

--- a/ts-packages/transform/src/config.ts
+++ b/ts-packages/transform/src/config.ts
@@ -1,4 +1,4 @@
-import * as metadata from "@ask-lang/contract-metadata";
+import * as metadata from "contract-metadata";
 
 export interface AskConfig {
     /**

--- a/ts-packages/transform/src/metadata/generator.ts
+++ b/ts-packages/transform/src/metadata/generator.ts
@@ -34,8 +34,8 @@ import {
     SequenceDef,
     ArrayDef,
     VersionedContractMetadata,
-} from "@ask-lang/contract-metadata";
-import * as metadata from "@ask-lang/contract-metadata";
+} from "contract-metadata";
+import * as metadata from "contract-metadata";
 import { ASK_VERSION } from "../consts";
 import {
     extractConfigFromDecorator,

--- a/ts-packages/transform/src/metadata/typeInfo.ts
+++ b/ts-packages/transform/src/metadata/typeInfo.ts
@@ -1,4 +1,4 @@
-import * as metadata from "@ask-lang/contract-metadata";
+import * as metadata from "contract-metadata";
 import { Field, Type } from "visitor-as/as";
 
 /**

--- a/ts-packages/transform/src/metadata/typeResolver.ts
+++ b/ts-packages/transform/src/metadata/typeResolver.ts
@@ -15,7 +15,7 @@ import {
 } from "visitor-as/as";
 import { isMessage, isConstructor } from "./generator";
 import debug from "debug";
-import { PrimitiveType } from "@ask-lang/contract-metadata";
+import { PrimitiveType } from "contract-metadata";
 import {
     PrimitiveTypeInfo,
     CompositeTypeInfo,


### PR DESCRIPTION
Since `AS` do not support namespace correctly, we remove `@ask-lang` namespace from packages this time.