### PR TITLE
fix: do not export `__unstable__` from inside `seal0`

### DIFF
--- a/as-packages/as-contract-runtime/assembly/seal0.ts
+++ b/as-packages/as-contract-runtime/assembly/seal0.ts
@@ -1,7 +1,5 @@
 import { Ptr, ReturnCode, Size } from ".";
 
-export * from "./unstable";
-
 
 // Set the value at the given key in the contract storage.
 //


### PR DESCRIPTION
Ref #243

I see no reason to overshadow the exports inside `seal0.ts` with the ones from `__unstable__.ts`. Also considering many of the host functions inside `__unstable__.ts` are now stabled and move to `seal1`.

For Example:-
We have `seal_clear_storage`  in `seal0`
https://github.com/ask-lang/ask/blob/630b2dbc8266997918e6f5766f05440f2bad4e7a/as-packages/as-contract-runtime/assembly/seal0.ts#L18-L24

and the new `seal_clear_storage` in `__unstable__.ts` which is exported on the top of `seal0.ts` file
https://github.com/ask-lang/ask/blob/630b2dbc8266997918e6f5766f05440f2bad4e7a/as-packages/as-contract-runtime/assembly/unstable.ts#L24-L35