### PR TITLE
feat: add `delete` method in `Vector<T>`

### DIFF
--- a/as-packages/lang/assembly/collections/vector.ts
+++ b/as-packages/lang/assembly/collections/vector.ts
@@ -47,6 +47,15 @@ export class Vector<T> implements SpreadLayout {
     }
 
     /**
+     * Remove the element at given index.
+     * @param index 
+     */
+    delete(index: u32): void {
+        assert(this.length > index);
+        this._elems.deleteAt(index);
+    }
+
+    /**
      * Returns true if the length is zero.
      * @returns
      */


### PR DESCRIPTION
Add the missing delete by index operation for `Vector<T>` collection.
Also should we add `remove` too, just like in `LazyIndexMap<T>` ?