### PR TITLE
Ask! Tuple & Enum Support (Experimental)

### DIFF
--- a/as-packages/as-contract-runtime/assembly/seal0.ts
+++ b/as-packages/as-contract-runtime/assembly/seal0.ts
@@ -1,6 +1,6 @@
 import { Ptr, ReturnCode, Size } from ".";
 
-export * from "./unstable";
+// export * from "./unstable";
 
 
 // Set the value at the given key in the contract storage.

--- a/as-packages/lang/assembly/env/onchain.ts
+++ b/as-packages/lang/assembly/env/onchain.ts
@@ -44,6 +44,12 @@ export class EnvInstance implements TypedEnvBackend {
         return ScaleDeserializer.deserialize<T>(BytesBuffer.wrap(storageBuffer.buffer));
     }
 
+    @inline
+    debugMessage(message: string): void {
+        const buffer = String.UTF8.encode(message); 
+        seal0.seal_debug_message(changetype<u32>(buffer), buffer.byteLength);
+    }
+
     setContractStorage<K extends IKey, V>(
         key: K,
         value: V

--- a/as-packages/lang/assembly/interfaces/backend.ts
+++ b/as-packages/lang/assembly/interfaces/backend.ts
@@ -49,6 +49,8 @@ export interface EnvBackend {
      */
     returnValue<V>(flags: u32, value: V): void;
 
+    debugMessage(message: string): void;
+
     // TODO: add more methods
 }
 

--- a/ts-packages/contract-metadata/src/specs.ts
+++ b/ts-packages/contract-metadata/src/specs.ts
@@ -113,7 +113,7 @@ export type ICompositeDef = Def<{
 }>;
 
 export type IVariantDef = Def<{
-    readonly variants: Array<IVariant>;
+    readonly variant: { readonly variants: Array<IVariant> };
     // readonly path: Array<string>;
 }>;
 

--- a/ts-packages/contract-metadata/src/specs.ts
+++ b/ts-packages/contract-metadata/src/specs.ts
@@ -86,9 +86,10 @@ export type IPrimitiveDef = Def<{
 }>;
 
 export type ITupleDef = Def<{
-    readonly tuple: {
-        readonly fields: Array<number>;
-    };
+    readonly tuple: Array<number>;
+    // readonly tuple: {
+    //     readonly fields: Array<number>;
+    // };
 }>;
 
 export type IArrayDef = Def<{
@@ -118,14 +119,14 @@ export type IVariantDef = Def<{
 
 export interface IVariant {
     readonly name: string;
-    readonly fields: Array<IField>;
-    readonly discriminant: number | null;
+    readonly fields: Array<IField> | null;
+    readonly index: number;
 }
 
 export interface IField {
     readonly name: string | null;
     readonly type: number;
-    readonly typeName: string;
+    readonly typeName: string | null;
 }
 
 export interface IContract {

--- a/ts-packages/contract-metadata/src/types.ts
+++ b/ts-packages/contract-metadata/src/types.ts
@@ -77,9 +77,7 @@ export class TupleDef implements Type {
     toMetadata(): ITupleDef {
         return {
             def: {
-                tuple: {
-                    fields: this.fields,
-                },
+                tuple: this.fields,
             },
             path: null,
         };
@@ -195,15 +193,15 @@ export class VariantDef implements Type {
 export class Variant implements ToMetadata {
     constructor(
         public readonly name: string,
-        public readonly fields: Array<Field>,
-        public readonly discriminant: number | null,
+        public readonly fields: Array<Field> | null,
+        public readonly index: number,
     ) {}
 
     toMetadata(): IVariant {
         return {
             name: this.name,
-            fields: this.fields.map((f) => f.toMetadata()),
-            discriminant: this.discriminant,
+            fields: this.fields ? this.fields.map((f) => f.toMetadata()) : null,
+            index: this.index,
         };
     }
 }

--- a/ts-packages/contract-metadata/src/types.ts
+++ b/ts-packages/contract-metadata/src/types.ts
@@ -163,7 +163,7 @@ export class VariantDef implements Type {
     toMetadata(): IVariantDef {
         return {
             def: {
-                variants: this.variants.map((v) => v.toMetadata()),
+                variant: { variants: this.variants.map((v) => v.toMetadata()) },
             },
             path: this.path.length > 0 ? this.path : null,
         };

--- a/ts-packages/transform/src/ast.ts
+++ b/ts-packages/transform/src/ast.ts
@@ -14,6 +14,10 @@ import blake from "blakejs";
  * Ask supported decorators.
  */
 export enum ContractDecoratorKind {
+    // tuple
+    Tuple = "tuple",
+    Enumeration = "enumeration",
+    Variant = "variant",
     SpreadLayout = "spreadLayout",
     PackedLayout = "packedLayout",
     Contract = "contract",

--- a/ts-packages/transform/src/metadata/generator.ts
+++ b/ts-packages/transform/src/metadata/generator.ts
@@ -234,6 +234,7 @@ export class MetadataGenerator {
         const variants: metadata.Variant[] = info.fields.map(
             ({ field, isEmpty, innerFields }, idx) => {
                 const fieldDecl = field.prototype.declaration as FieldDeclaration;
+                const index = info.fields.length - idx - 1;
 
                 if (isEmpty) {
                     // empty variant
@@ -241,7 +242,7 @@ export class MetadataGenerator {
                         fieldDecl.name.range.toString(),
                         null,
                         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                        idx,
+                        index,
                     );
                 } else {
                     // either composite or tuple
@@ -287,7 +288,7 @@ export class MetadataGenerator {
                         }
                     });
 
-                    return new Variant(fieldDecl.name.range.toString(), variantFields, idx);
+                    return new Variant(fieldDecl.name.range.toString(), variantFields, index);
                 }
             },
         );

--- a/ts-packages/transform/src/metadata/typeInfo.ts
+++ b/ts-packages/transform/src/metadata/typeInfo.ts
@@ -1,5 +1,6 @@
 import * as metadata from "ask-contract-metadata";
 import { Field, Type } from "visitor-as/as";
+import { VariantField } from "./typeResolver";
 
 /**
  * TypeInfo contains some type infos needed for metadata types
@@ -12,9 +13,21 @@ export abstract class TypeInfo {
     ) {}
 }
 
+export class TupleTypeInfo extends TypeInfo {
+    constructor(type: Type, index: number, public readonly types: Type[]) {
+        super(type, index, metadata.TypeKind.Tuple);
+    }
+}
+
 export class CompositeTypeInfo extends TypeInfo {
     constructor(type: Type | null, index: number, public readonly fields: Field[] | Type[]) {
         super(type, index, metadata.TypeKind.Composite);
+    }
+}
+
+export class VariantTypeInfo extends TypeInfo {
+    constructor(type: Type | null, index: number, public readonly fields: VariantField[]) {
+        super(type, index, metadata.TypeKind.Variant);
     }
 }
 

--- a/ts-packages/transform/src/metadata/typeResolver.ts
+++ b/ts-packages/transform/src/metadata/typeResolver.ts
@@ -321,7 +321,7 @@ export class TypeResolver {
                     ? this.resovleCompositeField(field.type).map((f) => f.type)
                     : this.resovleCompositeField(field.type);
             }
-            fields.push({ field, isEmpty: field.type.isNumericValue, innerFields, variantDecl });
+            fields.push({ field, isEmpty, innerFields, variantDecl });
         }
 
         return fields;


### PR DESCRIPTION
# Ask! Tuple & Enum Support (Experimental)

AssemblyScript does not supports tuples and tagged-union types (Rust-like enums) and so does ask!.
The `Option<T>` and `Result<T, E>` are used extensively inside PSPs along with other enum types.
Therefore having their support in ask! is really important before ask! can be used to onboard new
developers from non Rust background.

## Notes :-
- All the types in storage should've no required argument in constructor, see https://github.com/ask-lang/ask/issues/245#issuecomment-1408074629


## Tuples

Tuples in ask! are objects anointed with `@tuple()` decorator. All it does is instruct the metadata generator
to output a Tuple type instead of a Composite one.

Below type is equivalent to Rust's `(u64, bool)`.

```ts
@tuple()
class MyTuple {
  constructor(public val0: u64 = 0, public val1: bool = false) {}
}
```

Generic implementations for tuples are provided in ['tuples.ts'](./assembly/tuple.ts) and recommended over creating a new tuple type.

### Compatibility

- `@serialize()` - works fine
- `@deserialize()` - works fine
- `@packedLayout()` - works fine
- `@spreadLayout()` - works fine

## Enums

Rust like enums (or tagged union types) can be defined using the combination of `@enumeration()` and `@variant()` decorators.

```rust
enum MyType {
  EmptyVariant,
  U8(u8),
  WithFields { message: String, index: u64 },
}
```

```ts
enum MyTypeEnum {
  EmptyVariant,
  U8,
  WithFields,
}

@serialize()
@deserialize()
class WithFields {
  constructor(public message: string = '', public index: u64 = 0) {}
}

@enumeration()
class MyType {
  public type: MyTypeEnum = MyTypeEnum.EmptyVariant;

  private constructor() {}

  //
  // ENUM VARIANTS
  //

  // Empty variant, to declare empty variant use numeric types
  @variant({ name: 'EmptyVariant' })
  _empty: u8 = 0;
  // Tuple variant, use the tuple types
  @variant({ name: 'U8' })
  _u8: Tuple1<u8> = instantiateZero<Tuple1<u8>>();
  // Composite variants, use normal objects
  @variant({ name: 'WithFields' })
  _withFields: WithFields = instantiateZero<WithFields>();

  //
  // Variants Constructors
  //

  static EmptyVariant(): MyType {
    const enum = new MyType();
    enum.type = MyTypeEnum.EmptyVariant;
    return enum;
  }

  static U8(val: u8): MyType {
    const enum = new MyType();
    enum.type = MyTypeEnum.U8;
    enum._u8 = val;
    return enum;
  }

  static WithFields(val: WithFields): MyType {
    const enum = new MyType();
    enum.type = MyTypeEnum.WithFields;
    enum._withFields = val;
    return enum;
  }

  //
  // Variants Getters
  //

  U8(): u8 {
    return this._u8.val0;
  }

  WithFields(): WithFields {
    return this._withFields;
  }


  // For Serialization and Packed Layout
  // See the other enum examples
}
```

### Other Examples :-

- [`Option<T>`](https://github.com/ashutoshvarma/psp34-contract/blob/feat/enum/packages/common/assembly/option.ts) (adapted from `as-containers`)
- [`Result<T>`](https://github.com/ashutoshvarma/psp34-contract/blob/feat/enum/packages/common/assembly/result.ts) (adapted from `as-containers`)
- [`Id`](https://github.com/ashutoshvarma/psp34-contract/blob/feat/enum/packages/psp34/assembly/types/id.ts) (from PSP34 Spec)
- [`PSP34Error`](https://github.com/ashutoshvarma/psp34-contract/blob/feat/enum/packages//psp34/assembly/types/errors.ts) (from PSP34 Spec)

Please go though this PSP34 implementation in ask! for understanding more about enum support - https://github.com/ashutoshvarma/psp34-contract/tree/feat/enum/packages/psp34/assembly/psp34

### Compatibility

Does not support `SpreadLayout` because ask! does not have something similar to ink! v0.3's [`FOOTPRINT`](https://github.com/paritytech/ink/blob/83800c7068b4745b42bc473d5f80d2af12996d6b/crates/storage/src/traits/spread.rs#LL51C16-L51C16). I've experimented with adding that to ask!, you can find it here - https://github.com/ashutoshvarma/ask/commit/8671900c2444bc0babe499373bc80dc20ded96f5.
If using inside a spread layout type, use it with `Pack<T>`.

- `@serialize()` - needs manual implementation
- `@deserialize()` - needs manual implementation
- `@packedLayout()` - needs manual implementation
- `@spreadLayout()` - does not support spread layout at all


## TODO
- [x] Add support for Tuple in metadata
- [x] Add support for Enum in metadata
- [ ] Add support for `serialize()` & `packedLayout()` decorators for Enum 
